### PR TITLE
test: expand coverage and ratchet threshold to 70%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - run: pytest tests/ -v --tb=short
       - name: Run coverage
         if: matrix.python-version == '3.12'
-        run: pytest tests/ --cov=slack_migrator --cov-report=xml --cov-fail-under=55
+        run: pytest tests/ --cov=slack_migrator --cov-report=xml --cov-fail-under=70
       - name: Upload coverage artifact
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,4 +128,4 @@ source = ["slack_migrator"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-fail_under = 55
+fail_under = 70

--- a/tests/unit/test_drive_uploader.py
+++ b/tests/unit/test_drive_uploader.py
@@ -436,6 +436,48 @@ class TestUploadFileToDrive:
         # create should NOT have been called
         uploader.drive_service.files().create.assert_not_called()
 
+    @patch("slack_migrator.services.drive.drive_uploader.MediaFileUpload")
+    def test_reused_file_sets_poster_permission(self, mock_media_cls, tmp_path):
+        """Sets poster permission on reused file when message_poster_email provided."""
+        uploader = _make_uploader()
+        uploader.folders_pre_cached.add("folder1")
+
+        test_file = tmp_path / "dup.txt"
+        content = b"duplicate content"
+        test_file.write_bytes(content)
+        file_hash = hashlib.md5(content).hexdigest()  # noqa: S324
+
+        uploader.file_hash_cache[file_hash] = (
+            "existing_id",
+            "https://existing_link",
+        )
+
+        mock_get = MagicMock()
+        mock_get.execute.return_value = {
+            "id": "existing_id",
+            "webViewLink": "https://existing_link",
+        }
+        uploader.drive_service.files().get.return_value = mock_get
+
+        mock_perm_create = MagicMock()
+        mock_perm_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_perm_create
+
+        file_id, _url = uploader.upload_file_to_drive(
+            str(test_file),
+            "dup.txt",
+            "folder1",
+            message_poster_email="poster@example.com",
+        )
+
+        assert file_id == "existing_id"
+        uploader.drive_service.files().create.assert_not_called()
+        uploader.drive_service.permissions().create.assert_called_once()
+        call_kwargs = uploader.drive_service.permissions().create.call_args
+        body = call_kwargs.kwargs.get("body", call_kwargs[1].get("body"))
+        assert body["emailAddress"] == "poster@example.com"
+        assert body["role"] == "editor"
+
 
 # -------------------------------------------------------------------
 # TestSetMessagePosterPermission (_share_file_with_domain)
@@ -511,3 +553,387 @@ class TestInit:
         assert uploader.file_hash_cache == {}
         assert uploader.folders_pre_cached == set()
         assert uploader.migrator is None
+
+
+# -------------------------------------------------------------------
+# TestSetFilePermissionsForUsers
+# -------------------------------------------------------------------
+
+
+class TestSetFilePermissionsForUsers:
+    """Tests for set_file_permissions_for_users."""
+
+    def test_single_user_gets_reader_role(self):
+        """A user not matching message_poster gets reader role."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users(
+            "file1", ["reader@example.com"]
+        )
+
+        assert result is True
+        call_kwargs = uploader.drive_service.permissions().create.call_args
+        body = call_kwargs.kwargs.get("body", call_kwargs[1].get("body"))
+        assert body["role"] == "reader"
+
+    def test_message_poster_in_list_gets_editor(self):
+        """Message poster in user list gets editor role."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users(
+            "file1",
+            ["poster@example.com"],
+            message_poster_email="poster@example.com",
+        )
+
+        assert result is True
+        call_kwargs = uploader.drive_service.permissions().create.call_args
+        body = call_kwargs.kwargs.get("body", call_kwargs[1].get("body"))
+        assert body["role"] == "editor"
+
+    def test_message_poster_not_in_list_added_separately(self):
+        """Message poster not in user_emails gets added with editor role."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users(
+            "file1",
+            ["reader@example.com"],
+            message_poster_email="poster@example.com",
+        )
+
+        assert result is True
+        # Should have 2 calls: reader + poster
+        assert uploader.drive_service.permissions().create.call_count == 2
+
+    def test_service_account_gets_editor(self):
+        """Service account always gets editor permission."""
+        uploader = _make_uploader(service_account_email="sa@example.com")
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users(
+            "file1", ["reader@example.com"]
+        )
+
+        assert result is True
+        # 1 reader + 1 service account
+        assert uploader.drive_service.permissions().create.call_count == 2
+
+    def test_partial_failure(self):
+        """Some users fail but processing continues."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        # First succeeds, second fails
+        mock_create.execute.side_effect = [
+            {"id": "perm1"},
+            _http_error(403, "Forbidden"),
+        ]
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users(
+            "file1", ["a@example.com", "b@example.com"]
+        )
+
+        assert result is False
+
+    def test_http_error_logged_not_crash(self):
+        """HttpError during permission creation doesn't crash."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        mock_create.execute.side_effect = _http_error(500, "Server Error")
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users("file1", ["user@example.com"])
+
+        assert result is False
+
+    def test_empty_user_emails_returns_false(self):
+        """Empty user list returns False."""
+        uploader = _make_uploader()
+
+        result = uploader.set_file_permissions_for_users("file1", [])
+
+        assert result is False
+
+    def test_all_permissions_succeed_returns_true(self):
+        """Returns True when all permissions are set successfully."""
+        uploader = _make_uploader(service_account_email="sa@example.com")
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.set_file_permissions_for_users(
+            "file1",
+            ["a@example.com", "b@example.com"],
+            message_poster_email="a@example.com",
+        )
+
+        assert result is True
+        # 2 users + 1 service account = 3
+        assert uploader.drive_service.permissions().create.call_count == 3
+
+
+# -------------------------------------------------------------------
+# TestTransferOwnership
+# -------------------------------------------------------------------
+
+
+class TestTransferOwnership:
+    """Tests for transfer_ownership."""
+
+    def test_successful_transfer(self):
+        """Successful ownership transfer returns True."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.transfer_ownership("file1", "owner@example.com")
+
+        assert result is True
+        call_kwargs = uploader.drive_service.permissions().create.call_args
+        assert (
+            call_kwargs.kwargs.get(
+                "transferOwnership",
+                call_kwargs[1].get("transferOwnership"),
+            )
+            is True
+        )
+
+    def test_dry_run_does_not_call_api(self):
+        """Dry run logs but doesn't call API."""
+        uploader = _make_uploader(dry_run=True)
+
+        result = uploader.transfer_ownership("file1", "owner@example.com")
+
+        assert result is True
+        uploader.drive_service.permissions().create.assert_not_called()
+
+    def test_http_error_returns_false(self):
+        """HttpError during transfer returns False."""
+        uploader = _make_uploader()
+        mock_create = MagicMock()
+        mock_create.execute.side_effect = _http_error(403, "Forbidden")
+        uploader.drive_service.permissions().create.return_value = mock_create
+
+        result = uploader.transfer_ownership("file1", "owner@example.com")
+
+        assert result is False
+
+
+# -------------------------------------------------------------------
+# Additional edge-case tests for pre_cache and find_file_by_hash
+# -------------------------------------------------------------------
+
+
+class TestPreCacheFolderFileHashesSharedDrive:
+    """Tests for pre_cache_folder_file_hashes with shared_drive_id."""
+
+    def test_shared_drive_params_included(self):
+        """Shared drive params (corpora, driveId, etc.) are included."""
+        uploader = _make_uploader()
+
+        mock_list = MagicMock()
+        mock_list.execute.return_value = {"files": []}
+        uploader.drive_service.files().list.return_value = mock_list
+
+        uploader.pre_cache_folder_file_hashes("folder1", shared_drive_id="sd1")
+
+        call_kwargs = uploader.drive_service.files().list.call_args
+        assert call_kwargs.kwargs.get("driveId", call_kwargs[1].get("driveId")) == "sd1"
+        assert (
+            call_kwargs.kwargs.get(
+                "includeItemsFromAllDrives",
+                call_kwargs[1].get("includeItemsFromAllDrives"),
+            )
+            is True
+        )
+
+    def test_skips_files_without_hash(self):
+        """Files missing md5Checksum or id are not cached."""
+        uploader = _make_uploader()
+
+        api_response = {
+            "files": [
+                {"id": "f1", "name": "a.txt", "webViewLink": "https://l1"},
+                {
+                    "id": "f2",
+                    "name": "b.txt",
+                    "md5Checksum": "hash2",
+                    "webViewLink": "https://l2",
+                },
+            ]
+        }
+        mock_list = MagicMock()
+        mock_list.execute.return_value = api_response
+        uploader.drive_service.files().list.return_value = mock_list
+
+        count = uploader.pre_cache_folder_file_hashes("folder1")
+
+        assert count == 1
+        assert "hash2" in uploader.file_hash_cache
+
+
+class TestFindFileByHashCacheMiss:
+    """Tests for _find_file_by_hash when cached file no longer exists."""
+
+    def test_cached_file_deleted_falls_back_to_search(self):
+        """When cached file verification fails, falls back to API search."""
+        uploader = _make_uploader()
+        uploader.file_hash_cache["hash1"] = ("old_id", "https://old_link")
+
+        # Verification fails (file deleted)
+        mock_get = MagicMock()
+        mock_get.execute.side_effect = Exception("File not found")
+        uploader.drive_service.files().get.return_value = mock_get
+
+        # API search finds the file with new ID
+        mock_list = MagicMock()
+        mock_list.execute.return_value = {
+            "files": [
+                {
+                    "id": "new_id",
+                    "name": "test.txt",
+                    "webViewLink": "https://new_link",
+                }
+            ]
+        }
+        uploader.drive_service.files().list.return_value = mock_list
+
+        file_id, link = uploader._find_file_by_hash("hash1", "test.txt", "folder1")
+
+        assert file_id == "new_id"
+        assert link == "https://new_link"
+        # Old cache entry replaced
+        assert uploader.file_hash_cache["hash1"] == ("new_id", "https://new_link")
+
+    def test_shared_drive_search_params(self):
+        """Shared drive params passed to file search."""
+        uploader = _make_uploader()
+
+        mock_list = MagicMock()
+        mock_list.execute.return_value = {"files": []}
+        uploader.drive_service.files().list.return_value = mock_list
+
+        uploader._find_file_by_hash(
+            "hash1", "test.txt", "folder1", shared_drive_id="sd1"
+        )
+
+        call_kwargs = uploader.drive_service.files().list.call_args
+        assert call_kwargs.kwargs.get("driveId", call_kwargs[1].get("driveId")) == "sd1"
+
+
+class TestUploadFileToDriveAdditional:
+    """Additional tests for upload_file_to_drive."""
+
+    @patch("slack_migrator.services.drive.drive_uploader.MediaFileUpload")
+    def test_default_mime_type_fallback(self, mock_media_cls, tmp_path):
+        """Unknown file extension falls back to application/octet-stream."""
+        uploader = _make_uploader()
+        uploader.folders_pre_cached.add("folder1")
+
+        test_file = tmp_path / "data.xyz123"
+        test_file.write_bytes(b"binary data")
+
+        mock_list = MagicMock()
+        mock_list.execute.return_value = {"files": []}
+        uploader.drive_service.files().list.return_value = mock_list
+
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {
+            "id": "file_id",
+            "webViewLink": "https://link",
+        }
+        uploader.drive_service.files().create.return_value = mock_create
+
+        file_id, _url = uploader.upload_file_to_drive(
+            str(test_file), "data.xyz123", "folder1"
+        )
+
+        assert file_id == "file_id"
+        # Verify MediaFileUpload was called with octet-stream
+        mock_media_cls.assert_called_once_with(
+            str(test_file), mimetype="application/octet-stream"
+        )
+
+    @patch("slack_migrator.services.drive.drive_uploader.MediaFileUpload")
+    def test_upload_with_shared_drive(self, mock_media_cls, tmp_path):
+        """Upload to shared drive includes supportsAllDrives."""
+        uploader = _make_uploader()
+        uploader.folders_pre_cached.add("folder1")
+
+        test_file = tmp_path / "upload.txt"
+        test_file.write_bytes(b"content")
+
+        mock_list = MagicMock()
+        mock_list.execute.return_value = {"files": []}
+        uploader.drive_service.files().list.return_value = mock_list
+
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {
+            "id": "new_id",
+            "webViewLink": "https://new_link",
+        }
+        uploader.drive_service.files().create.return_value = mock_create
+
+        file_id, _url = uploader.upload_file_to_drive(
+            str(test_file), "upload.txt", "folder1", shared_drive_id="sd1"
+        )
+
+        assert file_id == "new_id"
+        call_kwargs = uploader.drive_service.files().create.call_args
+        assert (
+            call_kwargs.kwargs.get(
+                "supportsAllDrives",
+                call_kwargs[1].get("supportsAllDrives"),
+            )
+            is True
+        )
+
+    @patch("slack_migrator.services.drive.drive_uploader.MediaFileUpload")
+    def test_upload_sets_poster_permission_on_new_file(self, mock_media_cls, tmp_path):
+        """Message poster email triggers permission call on new upload."""
+        uploader = _make_uploader()
+        uploader.folders_pre_cached.add("folder1")
+
+        test_file = tmp_path / "upload.txt"
+        test_file.write_bytes(b"content")
+
+        mock_list = MagicMock()
+        mock_list.execute.return_value = {"files": []}
+        uploader.drive_service.files().list.return_value = mock_list
+
+        mock_create = MagicMock()
+        mock_create.execute.return_value = {
+            "id": "new_id",
+            "webViewLink": "https://link",
+        }
+        uploader.drive_service.files().create.return_value = mock_create
+
+        mock_perm_create = MagicMock()
+        mock_perm_create.execute.return_value = {"id": "perm1"}
+        uploader.drive_service.permissions().create.return_value = mock_perm_create
+
+        file_id, _url = uploader.upload_file_to_drive(
+            str(test_file),
+            "upload.txt",
+            "folder1",
+            message_poster_email="poster@example.com",
+        )
+
+        assert file_id == "new_id"
+        uploader.drive_service.permissions().create.assert_called_once()
+        call_kwargs = uploader.drive_service.permissions().create.call_args
+        body = call_kwargs.kwargs.get("body", call_kwargs[1].get("body"))
+        assert body["emailAddress"] == "poster@example.com"
+        assert body["role"] == "editor"

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,0 +1,664 @@
+"""Unit tests for the unified permission validation system."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from slack_migrator.exceptions import PermissionCheckError
+from slack_migrator.utils.permissions import (
+    PermissionCheckContext,
+    PermissionValidator,
+    check_permissions_standalone,
+    validate_permissions,
+)
+
+# -------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------
+
+
+def _make_context(chat=None, drive=None, admin="admin@example.com"):
+    """Build a PermissionCheckContext with mocked services."""
+    return PermissionCheckContext(
+        chat=chat or MagicMock(),
+        drive=drive or MagicMock(),
+        workspace_admin=admin,
+    )
+
+
+def _http_error(status=400, reason="Bad Request", content=b"error"):
+    """Create an HttpError for testing."""
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = reason
+    return HttpError(resp=resp, content=content)
+
+
+def _setup_space_creation(chat, space_name="spaces/test123"):
+    """Configure chat mock so space creation succeeds."""
+    chat.spaces().create().execute.return_value = {"name": space_name}
+
+
+def _setup_space_and_member(chat, space_name="spaces/test123"):
+    """Configure chat mock so both space creation and member ops succeed."""
+    _setup_space_creation(chat, space_name)
+    chat.spaces().members().list().execute.return_value = {"memberships": []}
+    chat.spaces().members().create().execute.return_value = {
+        "name": f"{space_name}/members/m1"
+    }
+
+
+# -------------------------------------------------------------------
+# TestPermissionValidatorInit
+# -------------------------------------------------------------------
+
+
+class TestPermissionValidatorInit:
+    """Tests for PermissionValidator.__init__."""
+
+    def test_accepts_permission_check_context(self):
+        """Accepts a PermissionCheckContext dataclass."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        assert validator.migrator is ctx
+        assert validator.permission_errors == []
+        assert validator.test_resources == {}
+
+    def test_accepts_migrator_like_object(self):
+        """Accepts any object with .chat, .drive, .workspace_admin."""
+        migrator = MagicMock()
+        migrator.chat = MagicMock()
+        migrator.drive = MagicMock()
+        migrator.workspace_admin = "admin@example.com"
+        validator = PermissionValidator(migrator)
+        assert validator.migrator is migrator
+
+
+# -------------------------------------------------------------------
+# TestSpaceOperations
+# -------------------------------------------------------------------
+
+
+class TestSpaceOperations:
+    """Tests for _test_space_operations."""
+
+    def test_happy_path_space_created_and_listed(self):
+        """Space creation and listing both succeed."""
+        ctx = _make_context()
+        _setup_space_creation(ctx.chat)
+        ctx.chat.spaces().list().execute.return_value = {"spaces": []}
+
+        validator = PermissionValidator(ctx)
+        validator._test_space_operations()
+
+        assert validator.permission_errors == []
+        assert validator.test_resources["space"] == "spaces/test123"
+
+    def test_creation_http_error(self):
+        """Space creation HttpError logged, no crash, early return."""
+        ctx = _make_context()
+        ctx.chat.spaces().create().execute.side_effect = _http_error(403, "Forbidden")
+
+        validator = PermissionValidator(ctx)
+        validator._test_space_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Space creation failed" in validator.permission_errors[0]
+        assert "space" not in validator.test_resources
+
+    def test_listing_http_error(self):
+        """Space listing HttpError logged but doesn't prevent further tests."""
+        ctx = _make_context()
+        _setup_space_creation(ctx.chat)
+        ctx.chat.spaces().list().execute.side_effect = _http_error(403, "Forbidden")
+
+        validator = PermissionValidator(ctx)
+        validator._test_space_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Space listing failed" in validator.permission_errors[0]
+        # Space was still created
+        assert "space" in validator.test_resources
+
+
+# -------------------------------------------------------------------
+# TestMemberOperations
+# -------------------------------------------------------------------
+
+
+class TestMemberOperations:
+    """Tests for _test_member_operations."""
+
+    def test_happy_path_member_listed_and_created(self):
+        """Member listing and creation both succeed."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources["space"] = "spaces/test123"
+        validator.test_resources["space_create_time"] = "2024-01-01T00:00:00Z"
+
+        ctx.chat.spaces().members().list().execute.return_value = {"memberships": []}
+        ctx.chat.spaces().members().create().execute.return_value = {
+            "name": "spaces/test123/members/m1"
+        }
+
+        validator._test_member_operations()
+
+        assert validator.permission_errors == []
+
+    def test_skips_when_no_test_space(self):
+        """Skips member tests when no test space exists."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        # No space in test_resources
+
+        validator._test_member_operations()
+
+        assert validator.permission_errors == []
+        ctx.chat.spaces().members().list.assert_not_called()
+
+    def test_409_conflict_treated_as_success(self):
+        """409 Already a member treated as success."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources["space"] = "spaces/test123"
+        validator.test_resources["space_create_time"] = "2024-01-01T00:00:00Z"
+
+        ctx.chat.spaces().members().list().execute.return_value = {"memberships": []}
+        ctx.chat.spaces().members().create().execute.side_effect = _http_error(
+            409, "Conflict"
+        )
+
+        validator._test_member_operations()
+
+        assert validator.permission_errors == []
+
+    def test_import_mode_normal_membership_treated_as_success(self):
+        """'Adding normal memberships isn't supported' is expected in import mode."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources["space"] = "spaces/test123"
+        validator.test_resources["space_create_time"] = "2024-01-01T00:00:00Z"
+
+        ctx.chat.spaces().members().list().execute.return_value = {"memberships": []}
+        err = _http_error(
+            400,
+            "Bad Request",
+            b"Adding normal memberships isn't supported",
+        )
+        ctx.chat.spaces().members().create().execute.side_effect = err
+
+        validator._test_member_operations()
+
+        assert validator.permission_errors == []
+
+    def test_insufficient_scopes_treated_as_error(self):
+        """'insufficient authentication scopes' is a real error."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources["space"] = "spaces/test123"
+        validator.test_resources["space_create_time"] = "2024-01-01T00:00:00Z"
+
+        err = _http_error(
+            403,
+            "Forbidden",
+            b"insufficient authentication scopes",
+        )
+        ctx.chat.spaces().members().list().execute.side_effect = err
+
+        validator._test_member_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Member listing failed" in validator.permission_errors[0]
+
+
+# -------------------------------------------------------------------
+# TestMessageOperations
+# -------------------------------------------------------------------
+
+
+class TestMessageOperations:
+    """Tests for _test_message_operations."""
+
+    def test_happy_path_message_created(self):
+        """Message creation succeeds."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources["space"] = "spaces/test123"
+
+        ctx.chat.spaces().messages().create().execute.return_value = {
+            "name": "spaces/test123/messages/msg1"
+        }
+
+        validator._test_message_operations()
+
+        assert validator.permission_errors == []
+        assert validator.test_resources["message"] == "spaces/test123/messages/msg1"
+
+    def test_skips_when_no_test_space(self):
+        """Skips message tests when no test space exists."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+
+        validator._test_message_operations()
+
+        assert validator.permission_errors == []
+
+    def test_creation_failure_logged(self):
+        """Message creation failure adds to permission_errors."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources["space"] = "spaces/test123"
+
+        ctx.chat.spaces().messages().create().execute.side_effect = _http_error(
+            403, "Forbidden"
+        )
+
+        validator._test_message_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Message creation failed" in validator.permission_errors[0]
+
+
+# -------------------------------------------------------------------
+# TestDriveOperations
+# -------------------------------------------------------------------
+
+
+class TestDriveOperations:
+    """Tests for _test_drive_operations."""
+
+    def test_happy_path_file_created_and_permission_set(self):
+        """File creation and permission setting succeed."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+
+        ctx.drive.files().create().execute.return_value = {"id": "file123"}
+        ctx.drive.permissions().create().execute.return_value = {"id": "perm1"}
+
+        validator._test_drive_operations()
+
+        assert validator.permission_errors == []
+        assert validator.test_resources["drive_file"] == "file123"
+
+    def test_file_creation_fails(self):
+        """File creation failure adds to permission_errors."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+
+        ctx.drive.files().create().execute.side_effect = _http_error(403, "Forbidden")
+
+        validator._test_drive_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Drive operations failed" in validator.permission_errors[0]
+
+    def test_permission_creation_fails(self):
+        """Permission creation failure adds to permission_errors."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+
+        ctx.drive.files().create().execute.return_value = {"id": "file123"}
+        ctx.drive.permissions().create().execute.side_effect = _http_error(
+            403, "Forbidden"
+        )
+
+        validator._test_drive_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Drive operations failed" in validator.permission_errors[0]
+
+
+# -------------------------------------------------------------------
+# TestCleanup
+# -------------------------------------------------------------------
+
+
+class TestCleanup:
+    """Tests for _cleanup_test_resources."""
+
+    def test_cleans_up_both_space_and_drive_file(self):
+        """Cleans up both space and drive file when both exist."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {
+            "space": "spaces/test123",
+            "drive_file": "file123",
+        }
+
+        validator._cleanup_test_resources()
+
+        ctx.chat.spaces().delete.assert_called_once()
+        ctx.drive.files().delete.assert_called_once()
+
+    def test_handles_import_mode_deletion_errors(self):
+        """Import mode deletion error logged gracefully."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {"space": "spaces/test123"}
+
+        ctx.chat.spaces().delete().execute.side_effect = Exception(
+            "import mode: cannot delete"
+        )
+
+        # Should not raise
+        validator._cleanup_test_resources()
+
+    def test_noop_when_no_resources(self):
+        """No-op when no resources to clean up."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {}
+
+        validator._cleanup_test_resources()
+
+        ctx.chat.spaces().delete.assert_not_called()
+        ctx.drive.files().delete.assert_not_called()
+
+    def test_partial_cleanup_one_fails_other_still_attempted(self):
+        """When drive cleanup fails, space cleanup still attempted."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {
+            "drive_file": "file123",
+            "space": "spaces/test123",
+        }
+
+        ctx.drive.files().delete().execute.side_effect = Exception("drive error")
+
+        # Should not raise — space cleanup still attempted
+        validator._cleanup_test_resources()
+
+        ctx.chat.spaces().delete.assert_called_once()
+
+
+# -------------------------------------------------------------------
+# TestReportResults
+# -------------------------------------------------------------------
+
+
+class TestReportResults:
+    """Tests for _report_results."""
+
+    def test_no_errors_returns_true(self):
+        """No errors means success."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.permission_errors = []
+
+        assert validator._report_results() is True
+
+    def test_has_errors_raises_permission_check_error(self):
+        """Errors raise PermissionCheckError."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.permission_errors = ["error1", "error2"]
+
+        with pytest.raises(PermissionCheckError, match="2 errors"):
+            validator._report_results()
+
+    def test_error_message_includes_count(self):
+        """Error message includes number of accumulated errors."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.permission_errors = ["a", "b", "c"]
+
+        with pytest.raises(PermissionCheckError, match="3 errors"):
+            validator._report_results()
+
+
+# -------------------------------------------------------------------
+# TestValidateAllPermissions
+# -------------------------------------------------------------------
+
+
+class TestValidateAllPermissions:
+    """Tests for validate_all_permissions end-to-end."""
+
+    def test_all_pass_returns_true(self):
+        """All operations pass returns True."""
+        ctx = _make_context()
+        # Space ops
+        _setup_space_creation(ctx.chat)
+        ctx.chat.spaces().list().execute.return_value = {"spaces": []}
+        # Member ops
+        ctx.chat.spaces().members().list().execute.return_value = {"memberships": []}
+        ctx.chat.spaces().members().create().execute.return_value = {
+            "name": "spaces/test123/members/m1"
+        }
+        # Message ops
+        ctx.chat.spaces().messages().create().execute.return_value = {
+            "name": "spaces/test123/messages/msg1"
+        }
+        # Drive ops
+        ctx.drive.files().create().execute.return_value = {"id": "file123"}
+        ctx.drive.permissions().create().execute.return_value = {"id": "perm1"}
+
+        validator = PermissionValidator(ctx)
+        assert validator.validate_all_permissions() is True
+
+    def test_critical_exception_caught_and_reported(self):
+        """Unexpected exception during validation is caught and reported."""
+        ctx = _make_context()
+        ctx.chat.spaces().create().execute.side_effect = RuntimeError("unexpected")
+
+        validator = PermissionValidator(ctx)
+        with pytest.raises(PermissionCheckError):
+            validator.validate_all_permissions()
+
+        assert any(
+            "Critical validation error" in e for e in validator.permission_errors
+        )
+
+    def test_cleanup_runs_even_on_failure(self):
+        """Cleanup runs even when validation raises."""
+        ctx = _make_context()
+        _setup_space_creation(ctx.chat)
+        ctx.chat.spaces().list().execute.return_value = {"spaces": []}
+        # Fail on member listing
+        ctx.chat.spaces().members().list().execute.side_effect = _http_error(
+            403,
+            "Forbidden",
+            b"insufficient authentication scopes",
+        )
+        # Message ops fail because member error
+        ctx.chat.spaces().messages().create().execute.return_value = {
+            "name": "spaces/test123/messages/msg1"
+        }
+        # Drive ops succeed
+        ctx.drive.files().create().execute.return_value = {"id": "file123"}
+        ctx.drive.permissions().create().execute.return_value = {"id": "perm1"}
+
+        validator = PermissionValidator(ctx)
+        with pytest.raises(PermissionCheckError):
+            validator.validate_all_permissions()
+
+        # Space was created, so cleanup should have been called
+        ctx.chat.spaces().delete.assert_called()
+
+
+# -------------------------------------------------------------------
+# TestValidatePermissions
+# -------------------------------------------------------------------
+
+
+class TestValidatePermissions:
+    """Tests for the validate_permissions convenience function."""
+
+    def test_calls_initialize_then_delegates(self):
+        """Calls _initialize_api_services() then delegates to validator."""
+        migrator = MagicMock()
+        migrator.chat = MagicMock()
+        migrator.drive = MagicMock()
+        migrator.workspace_admin = "admin@example.com"
+
+        # Make all ops succeed
+        _setup_space_creation(migrator.chat)
+        migrator.chat.spaces().list().execute.return_value = {"spaces": []}
+        migrator.chat.spaces().members().list().execute.return_value = {
+            "memberships": []
+        }
+        migrator.chat.spaces().members().create().execute.return_value = {
+            "name": "spaces/t/members/m"
+        }
+        migrator.chat.spaces().messages().create().execute.return_value = {
+            "name": "spaces/t/messages/m"
+        }
+        migrator.drive.files().create().execute.return_value = {"id": "f1"}
+        migrator.drive.permissions().create().execute.return_value = {"id": "p1"}
+
+        result = validate_permissions(migrator)
+
+        migrator._initialize_api_services.assert_called_once()
+        assert result is True
+
+    def test_propagates_permission_check_error(self):
+        """Propagates PermissionCheckError from validator."""
+        migrator = MagicMock()
+        migrator.chat = MagicMock()
+        migrator.drive = MagicMock()
+        migrator.workspace_admin = "admin@example.com"
+
+        migrator.chat.spaces().create().execute.side_effect = _http_error(
+            403, "Forbidden"
+        )
+
+        with pytest.raises(PermissionCheckError):
+            validate_permissions(migrator)
+
+
+# -------------------------------------------------------------------
+# TestCheckPermissionsStandalone
+# -------------------------------------------------------------------
+
+
+class TestCheckPermissionsStandalone:
+    """Tests for check_permissions_standalone."""
+
+    @patch("slack_migrator.utils.permissions.get_gcp_service")
+    @patch("slack_migrator.core.config.load_config")
+    def test_happy_path(self, mock_load_config, mock_get_service, tmp_path):
+        """Happy path with mocked services."""
+        mock_config = MagicMock()
+        mock_config.max_retries = 3
+        mock_config.retry_delay = 1
+        mock_load_config.return_value = mock_config
+
+        chat_service = MagicMock()
+        drive_service = MagicMock()
+
+        # get_gcp_service called twice (chat, drive)
+        mock_get_service.side_effect = [chat_service, drive_service]
+
+        # Make all ops pass
+        _setup_space_creation(chat_service)
+        chat_service.spaces().list().execute.return_value = {"spaces": []}
+        chat_service.spaces().members().list().execute.return_value = {
+            "memberships": []
+        }
+        chat_service.spaces().members().create().execute.return_value = {
+            "name": "spaces/t/members/m"
+        }
+        chat_service.spaces().messages().create().execute.return_value = {
+            "name": "spaces/t/messages/m"
+        }
+        drive_service.files().create().execute.return_value = {"id": "f1"}
+        drive_service.permissions().create().execute.return_value = {"id": "p1"}
+
+        result = check_permissions_standalone(
+            "/fake/creds.json", "admin@example.com", "config.yaml"
+        )
+
+        assert result is True
+        assert mock_get_service.call_count == 2
+
+    @patch("slack_migrator.utils.permissions.get_gcp_service")
+    @patch("slack_migrator.core.config.load_config")
+    def test_config_not_found(self, mock_load_config, mock_get_service):
+        """Config file not found raises error."""
+        mock_load_config.side_effect = FileNotFoundError("config.yaml not found")
+
+        with pytest.raises(FileNotFoundError):
+            check_permissions_standalone(
+                "/fake/creds.json", "admin@example.com", "missing.yaml"
+            )
+
+    @patch("slack_migrator.utils.permissions.get_gcp_service")
+    @patch("slack_migrator.core.config.load_config")
+    def test_api_service_creation_fails(self, mock_load_config, mock_get_service):
+        """API service creation failure propagates."""
+        mock_config = MagicMock()
+        mock_config.max_retries = 3
+        mock_config.retry_delay = 1
+        mock_load_config.return_value = mock_config
+
+        mock_get_service.side_effect = ValueError("Invalid credentials")
+
+        with pytest.raises(ValueError, match="Invalid credentials"):
+            check_permissions_standalone(
+                "/bad/creds.json", "admin@example.com", "config.yaml"
+            )
+
+
+# -------------------------------------------------------------------
+# TestMemberOperationsWithoutSpaceCreateTime
+# -------------------------------------------------------------------
+
+
+class TestMemberOperationsEdgeCases:
+    """Edge-case tests for _test_member_operations."""
+
+    def test_fallback_when_space_create_time_missing(self):
+        """Uses fallback times when space_create_time is not in test_resources."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {"space": "spaces/test123"}
+        # Intentionally no space_create_time
+
+        ctx.chat.spaces().members().list().execute.return_value = {"memberships": []}
+        ctx.chat.spaces().members().create().execute.return_value = {
+            "name": "spaces/test123/members/m1"
+        }
+
+        validator._test_member_operations()
+
+        assert validator.permission_errors == []
+
+    def test_generic_member_creation_error(self):
+        """Generic HttpError during member creation is recorded."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {
+            "space": "spaces/test123",
+            "space_create_time": "2024-01-01T00:00:00Z",
+        }
+
+        ctx.chat.spaces().members().list().execute.return_value = {"memberships": []}
+        ctx.chat.spaces().members().create().execute.side_effect = _http_error(
+            500, "Internal Server Error"
+        )
+
+        validator._test_member_operations()
+
+        assert len(validator.permission_errors) == 1
+        assert "Member creation failed" in validator.permission_errors[0]
+
+    def test_member_listing_import_mode_not_available(self):
+        """'not available' in import mode is expected, not an error."""
+        ctx = _make_context()
+        validator = PermissionValidator(ctx)
+        validator.test_resources = {
+            "space": "spaces/test123",
+            "space_create_time": "2024-01-01T00:00:00Z",
+        }
+
+        err = _http_error(400, "Bad Request", b"not available in import mode")
+        ctx.chat.spaces().members().list().execute.side_effect = err
+        ctx.chat.spaces().members().create().execute.return_value = {
+            "name": "spaces/test123/members/m1"
+        }
+
+        validator._test_member_operations()
+
+        # "not available" is expected, should NOT be added as an error
+        assert validator.permission_errors == []


### PR DESCRIPTION
## Summary
- Add 34 tests for `utils/permissions.py` (14% → 98% coverage) covering all validator operations, cleanup, error reporting, and standalone entry points
- Add 19 tests for `services/drive/drive_uploader.py` (67% → 95% coverage) covering `set_file_permissions_for_users`, `transfer_ownership`, shared drive params, cache miss fallback, MIME type defaults, and poster permission verification on both new and hash-reused files
- Ratchet coverage threshold from 55% to 70% in both `pyproject.toml` and CI workflow (overall coverage now ~80%)

## Test plan
- [x] `pytest tests/ -x -q` — all 1018 tests pass
- [x] `pytest tests/ --cov=slack_migrator --cov-fail-under=70` — coverage meets new threshold
- [x] `ruff check slack_migrator/ tests/` — lint clean