### PR TITLE
refactor: tighten type annotations and fix silent exception swallowing

### DIFF
--- a/slack_migrator/core/context.py
+++ b/slack_migrator/core/context.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from slack_migrator.core.config import MigrationConfig
+from slack_migrator.types import SlackChannel
 
 
 @dataclass(frozen=True)
@@ -41,7 +42,7 @@ class MigrationContext:
     users_without_email: list[dict[str, Any]]
 
     # Channel metadata (from channels.json)
-    channels_meta: dict[str, Any]  # channel_name -> channel data
+    channels_meta: dict[str, SlackChannel]  # channel_name -> channel data
     channel_id_to_name: dict[str, str]
     channel_name_to_id: dict[str, str]
 

--- a/slack_migrator/core/state.py
+++ b/slack_migrator/core/state.py
@@ -9,6 +9,7 @@ State is organized into typed sub-state dataclasses by concern area.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -43,7 +44,7 @@ class SpaceState:
     created_spaces: dict[str, str] = field(default_factory=dict)
     channel_to_space: dict[str, str] = field(default_factory=dict)
     channel_id_to_space_id: dict[str, str] = field(default_factory=dict)
-    channel_handlers: dict[str, Any] = field(default_factory=dict)
+    channel_handlers: dict[str, logging.Handler] = field(default_factory=dict)
 
 
 @dataclass
@@ -87,7 +88,7 @@ class ErrorState:
     high_failure_rate_channels: dict[str, float] = field(default_factory=dict)
     incomplete_import_spaces: list[tuple[str, str]] = field(default_factory=list)
     channel_conflicts: set[str] = field(default_factory=set)
-    migration_issues: dict[str, Any] = field(default_factory=dict)
+    migration_issues: dict[str, str] = field(default_factory=dict)
     migration_errors: list[Any] = field(default_factory=list)
     channels_with_errors: list[str] = field(default_factory=list)
     channel_error_count: int = 0

--- a/slack_migrator/services/historical_membership.py
+++ b/slack_migrator/services/historical_membership.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import logging
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from googleapiclient.errors import HttpError
@@ -108,7 +109,7 @@ def _scan_message_files_for_membership(
 
 
 def _apply_channel_metadata_members(
-    meta: dict[str, Any],
+    meta: Mapping[str, Any],
     user_membership: dict[str, dict[str, Any]],
 ) -> set[str]:
     """Override active_users with the definitive member list from channels.json.

--- a/slack_migrator/utils/api.py
+++ b/slack_migrator/utils/api.py
@@ -421,9 +421,8 @@ class RetryWrapper:
                     data=request_data,
                     channel=channel_context,
                 )
-        except (ImportError, AttributeError, Exception):
-            # Silently ignore logging errors to not break API calls
-            pass
+        except Exception:
+            logger.debug("API logging failed", exc_info=True)
 
     def _log_api_response(
         self,
@@ -451,9 +450,8 @@ class RetryWrapper:
                     response_data=response_data,
                     channel=channel_context,
                 )
-        except (ImportError, AttributeError, Exception):
-            # Silently ignore logging errors to not break API calls
-            pass
+        except Exception:
+            logger.debug("API logging failed", exc_info=True)
 
 
 def slack_ts_to_rfc3339(ts: str) -> str:


### PR DESCRIPTION
## Summary

- **Type annotations**: Replace `dict[str, Any]` with concrete types where the actual value type is known:
  - `channels_meta` → `dict[str, SlackChannel]`
  - `channel_handlers` → `dict[str, logging.Handler]`
  - `migration_issues` → `dict[str, str]`
- **Silent exception fix**: Replace `except (ImportError, AttributeError, Exception): pass` with `except Exception: logger.debug(...)` in two API logging methods — errors are now visible at DEBUG level instead of silently swallowed
- Skipped `file_stats` typing (plan item 6.1b) — internal tracking dict keys don't match the `FileUploadStats` return TypedDict
- Skipped items 6.2 and 6.4 — already fixed in previous work

## Test plan

- [x] 1404 tests pass
- [x] mypy clean (including downstream `Mapping` fix for `_apply_channel_metadata_members`)
- [x] ruff lint + format clean