### PR TITLE
test: improve test quality — remove trivial tests, fix types and names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ source = ["slack_migrator"]
 show_missing = true
 skip_covered = true
 fail_under = 90
+# CLI orchestration modules are omitted because they wire together
+# already-tested services and require full end-to-end setup (credentials,
+# Slack export, Google API access) that unit tests cannot provide.
 omit = [
     "slack_migrator/cli/migrate_cmd.py",
     "slack_migrator/cli/cleanup_cmd.py",

--- a/tests/unit/test_channel_processor.py
+++ b/tests/unit/test_channel_processor.py
@@ -163,7 +163,7 @@ class TestProcessChannel:
     def test_channel_with_space_conflict(self, mock_should, tmp_path):
         """Channel with unresolved space conflict is skipped with errors."""
         processor = _make_processor()
-        processor.state.errors.channel_conflicts = {"general": ["spaces/A", "spaces/B"]}
+        processor.state.errors.channel_conflicts = {"general"}
 
         ch_dir = tmp_path / "general"
         ch_dir.mkdir()

--- a/tests/unit/test_message.py
+++ b/tests/unit/test_message.py
@@ -579,23 +579,16 @@ class TestSendMessage:
 
         assert "general:1700000000.000001" in state.messages.sent_messages
 
-    def test_state_has_thread_map_by_default(self):
-        """MigrationState initializes thread_map as an empty dict."""
-        state = _make_state()
+    def test_send_message_with_channel_none_returns_error(self):
+        """send_message returns an error when current_channel is None."""
+        ctx, state, chat, ur, ap = _make_send_deps(channel=None)
+        msg = {"ts": "1700000000.000001", "user": "U001", "text": "Hello"}
 
-        assert isinstance(state.messages.thread_map, dict)
+        result = send_message(ctx, state, chat, ur, ap, "spaces/SPACE1", msg)
 
-    def test_state_has_sent_messages_by_default(self):
-        """MigrationState initializes sent_messages as an empty set."""
-        state = _make_state()
-
-        assert isinstance(state.messages.sent_messages, set)
-
-    def test_state_has_message_id_map_by_default(self):
-        """MigrationState initializes message_id_map as an empty dict."""
-        state = _make_state()
-
-        assert isinstance(state.messages.message_id_map, dict)
+        assert result.success is False
+        assert result.error == "No current channel set"
+        chat.create_message.assert_not_called()
 
     def test_message_with_files_is_not_skipped(self):
         """Messages with no text but with files are not skipped."""
@@ -774,8 +767,8 @@ class TestProcessReactionsBatch:
 
         assert state.progress.migration_summary["reactions_created"] == 1
 
-    def test_external_user_reactions_skipped(self):
-        """Reactions from external users are skipped to avoid admin attribution."""
+    def test_external_user_reactions_counted_before_external_check(self):
+        """Reactions are counted in the summary before the external user check."""
         ctx, state, chat, ur = self._setup()
         ur.is_external_user.return_value = True
         reactions = [{"name": "thumbsup", "users": ["U001"]}]


### PR DESCRIPTION
## Summary

- Remove 3 trivial `isinstance(dict/set)` tests that only verify dataclass field types
- Rename `test_external_user_reactions_skipped` → `test_external_user_reactions_counted_before_external_check` (the reaction IS counted before the external check, not skipped)
- Fix `channel_conflicts` test: was using a `dict` but the type is `set[str]`
- Add test for `send_message` with `channel=None` (verifies error path)
- Add justifying comment for coverage omissions in `pyproject.toml`
- Skipped item 7.5 (dry-run with DryRunChatService) — current MagicMock test is valid

## Test plan

- [x] 1402 tests pass (net -2: removed 3 trivial, added 1 new)
- [x] Coverage at 95.45% (threshold: 90%)
- [x] ruff lint + format clean