### PR TITLE
fix: add diagnostic context to UserMappingError

### DIFF
--- a/src/slack_chat_migrator/services/user.py
+++ b/src/slack_chat_migrator/services/user.py
@@ -173,15 +173,18 @@ def generate_user_map(
         ]
         if no_id > 0:
             lines.append(f"  - {no_id}/{total} entries have no 'id' field.")
-            # Show a sample entry to help diagnose schema issues
-            # no_id > 0 guarantees users is non-empty
-            sample_keys = list(users[0].keys())[:8]
+            # Show a sample entry (one that lacks 'id') to help diagnose schema issues
+            # no_id > 0 guarantees at least one entry without an 'id' field
+            sample_user = next(u for u in users if not u.get("id"))
+            sample_keys = list(sample_user.keys())[:8]
             lines.append(f"  - Sample entry keys: {sample_keys}")
             lines.append(
                 "  - Expected format: each entry needs 'id' and 'profile.email'."
             )
         if no_email > 0:
-            lines.append(f"  - {no_email} users have no email in 'profile.email'.")
+            lines.append(
+                f"  - {no_email} user{' has' if no_email == 1 else 's have'} no email in 'profile.email'."
+            )
         if ignored_bots_count > 0:
             lines.append(
                 f"  - {ignored_bots_count} bot users were ignored (ignore_bots enabled)."
@@ -191,7 +194,6 @@ def generate_user_map(
         )
 
         detail = "\n".join(lines)
-        log_with_context(logging.ERROR, detail)
         raise UserMappingError(detail)
 
     log_with_context(logging.INFO, f"Generated user mapping for {len(user_map)} users")

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -200,7 +200,7 @@ class TestGenerateUserMap:
         users = [{"id": "U001", "name": "noemail", "profile": {}}]
         _write_users_json(tmp_path, users)
 
-        with pytest.raises(UserMappingError, match="1 users have no email") as exc:
+        with pytest.raises(UserMappingError, match="1 user has no email") as exc:
             generate_user_map(tmp_path, MigrationConfig())
 
         detail = str(exc.value)


### PR DESCRIPTION
## Summary
- When `generate_user_map()` finds no valid users, the `UserMappingError` now includes a detailed diagnostic breakdown: total entries parsed, entries missing `id` (with sample keys), users without emails, ignored bots count, and a tip pointing to `user_mapping_overrides`
- Adds 4 test cases covering each diagnostic branch (no-id, no-email, all-bots, empty list)

Closes #52

## Test plan
- [x] All 16 user mapping tests pass (`pytest tests/unit/test_user.py -v`)
- [x] Lint and type checks clean (`ruff check`, `mypy`)
- [ ] CI passes