### PR TITLE
bump: version 0.3.1 → 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,80 @@
-## Unreleased
+## v0.4.0 (2026-03-06)
+
+### BREAKING CHANGES
+
+- **Package renamed**: Import path changed from `slack_migrator` to `slack_chat_migrator`. CLI command renamed from `slack-migrator` to `slack-chat-migrator`.
+- **src layout adopted**: Package now uses the standard `src/` layout (`src/slack_chat_migrator/`).
+- **Build system migrated**: Moved from `setup.py` to `pyproject.toml`-only build configuration.
+- **CLI rewritten**: Migrated from argparse (single command) to Click with subcommands (`migrate`, `validate`, `init`, `setup`, `cleanup`).
 
 ### Feat
 
-- migrate CLI from argparse to click with subcommands (migrate, check-permissions, validate, cleanup)
-
-## v0.3.2 (2026-02-23)
+- **Click CLI with subcommands**: `migrate`, `validate`, `cleanup` replace the monolithic argparse interface
+- **Interactive setup wizard** (`setup`): Guided GCP project creation, API enablement, service account provisioning, and domain-wide delegation — all via REST APIs from the CLI
+- **Interactive config generator** (`init`): Step-by-step `config.yaml` creation with export path validation and optional post-init validation
+- **Rich CLI output**: Rich panels, tables, and spinners across all commands
+- **Live progress display**: Real-time migration progress with throughput metrics, error rates, member bars, and dry-run mode indicator
+- **Migration resumption**: `--resume` flag with checkpoint system to resume interrupted migrations
+- **Graceful interruption**: `InterruptHandler` catches Ctrl+C and completes the current channel before stopping
+- **`--complete` flag**: Inline import-mode completion (replaces deprecated `cleanup` command)
+- **Credential-free dry-run**: Run `migrate --dry-run` and `validate` without Google credentials
+- **Export inspector**: Analyze Slack export structure with channel/message/file counts in `validate` output
+- **ChatAdapter and DriveAdapter**: Typed wrappers over raw Google API services with consistent error handling
+- **DryRunChatService and DryRunDriveService**: No-op service implementations injected in dry-run mode
+- **Typed result dataclasses**: `SendResult` and `UploadResult` replace raw dicts for message and attachment operations
+- **Checkpoint system**: Periodic state snapshots enable migration resumption after interruption
 
 ### Fix
 
-- bump setuptools minimum to >=61 and make version dynamic
-- add type annotations to CLI/utility modules and enforce mypy in CI
-- add type annotations to service modules
-- add type annotations to core migrator module
-- delete empty logging.pyi stub and add googleapiclient to mypy overrides
-- resolve CI lint failures and strengthen emoji test assertion
-- surface skipped reactions from unmapped users in migration report
-- resolve ruff lint errors and fix CI workflow
-- Address PR review feedback
-- Add input validation, Python 3.9 compat, and improve update mode logic
-- Harden error handling in config, user, and file modules
-- Update broken config tests to match current schema
-- Replace bare except clause with except Exception in report.py
+- **Crash bugs and data-loss risks**: Fix `messages_created` counter increment, resolve crash paths across core modules
+- **Security hardening**: Escape single quotes in Drive API query strings (injection prevention), case-insensitive Bearer token check, credential handling improvements
+- **User mapping diagnostics**: Add context to `UserMappingError` for empty user maps, sample correct entries
+- **Bot handling**: Filter bots in dry-run reactions, handle `workspace_admin=None` in membership
+- **Silent exception handling**: Add debug logging to all previously silent exception handlers
+- **Narrow exception handlers**: Replace broad `except Exception` with specific exception types throughout
+- **Click 8.2+ compatibility**: Remove deprecated `mix_stderr` parameter
+- **Type annotations**: Add type annotations across all CLI, service, and core modules; enforce mypy in CI
+- **Input validation**: Python 3.9 compatibility, improved update mode logic
+- **Migration report**: Surface skipped reactions from unmapped users
 
 ### Refactor
 
-- migrate to pyproject.toml-only build configuration
-- narrow except Exception to specific exception types
-- extract magic numbers into named constants in space.py
-- add return type annotations to functions missing them
-- Harden credential handling and remove frame introspection in API utils
-- Fix bare except and improve HTTP debug logging in logging module
+- **Dependency injection**: `MigrationContext` (frozen dataclass) carries immutable config; `MigrationState` (mutable) tracks runtime state. Services receive only what they need — no more `migrator` back-references
+- **Package reorganization**: Services split into `services/messages/`, `services/spaces/`, `services/files/`, `services/setup/` subpackages
+- **Module extraction**: `ChannelProcessor`, `UserResolver`, `MigrationState`, `MigrationContext`, `migration_logging`, `cleanup` extracted from monolithic `migrator.py`
+- **Function decomposition**: Large functions decomposed into focused helpers across all modules
+- **Type safety**: ~50 `Any` annotations replaced with concrete types, `TypedDict`s for state, enums for sentinels (`UserType`, `MessageResult`, `ImportCompletionStrategy`), strict mypy on core modules
+- **Exception hierarchy**: Custom exceptions (`UserMappingError`, `SpacePermissionError`, etc.) replace `sys.exit()` calls and sentinel strings
+
+### Test
+
+- **Coverage raised from ~0% to 90%+** with 1541 unit tests
+- Tier 1/2/3 integration tests, dry-run pipeline tests, and comprehensive unit tests
+- Shared test fixtures and data builders
+
+### CI
+
+- Security scanning and pinned dependencies
+- Coverage threshold enforced at 90%
+- Dependabot: weekly updates for pip and GitHub Actions
+- Commitizen conventional commit enforcement
+
+### Docs
+
+- Updated README for new CLI commands and Quick Start guide
+- Google-style docstrings on all public methods
+- SECURITY.md and CODEOWNERS added
+
+### Dependencies
+
+- New: `click` (CLI framework), `rich` (terminal rendering)
+- New: `ruff` (linting/formatting, replaces black+isort+flake8)
+- New optional `[setup]`: `google-cloud-resource-manager`, `google-cloud-service-usage`
+- google-auth-httplib2 ~=0.3 (was ~=0.2)
+- emoji ~=2.15 (was ~=2.14)
+- pyyaml 6.0.3 (was 6.0.2)
+- requests 2.32.5 (was 2.32.4)
+- google-api-python-client 2.190.0 (was 2.177.0)
 
 ## v0.3.1 (2025-08-07)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ markers = [
 [tool.commitizen]
 name = "cz_conventional_commits"
 tag_format = "v$version"
-version = "0.3.2"
+version = "0.4.0"
 version_files = ["src/slack_chat_migrator/__init__.py:__version__"]
 update_changelog_on_bump = true
 

--- a/src/slack_chat_migrator/__init__.py
+++ b/src/slack_chat_migrator/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Slack to Google Chat migration tool."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- Bump version from 0.3.1 to 0.4.0
- Curated CHANGELOG.md with user-facing release notes covering all changes since v0.3.1
- Remove orphaned v0.3.2 changelog section (tag existed but was never published)