### PR TITLE
Replace GA4 with Cloudflare Web Analytics

### DIFF
--- a/site/src/components/CopyButton.tsx
+++ b/site/src/components/CopyButton.tsx
@@ -1,11 +1,5 @@
 import { useState, useCallback } from 'react';
 
-declare global {
-  interface Window {
-    gtag?: (...args: unknown[]) => void;
-  }
-}
-
 interface Props {
   text: string;
 }
@@ -14,9 +8,6 @@ export default function CopyButton({ text }: Props) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
-    if (typeof window.gtag === 'function') {
-      window.gtag('event', 'copy_command', { command_text: text });
-    }
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);

--- a/site/src/components/FAQ.astro
+++ b/site/src/components/FAQ.astro
@@ -18,7 +18,7 @@ const faqs = [
   },
   {
     question: 'Is this tool safe to run with domain-wide delegation?',
-    answer: 'The tool is MIT licensed and fully open source — read every line before you run it. It makes no external network calls beyond the Google APIs required for migration. Your service account credentials are used locally and never transmitted anywhere. The tool itself has no telemetry, analytics, or phoning home. This website uses cookieless Google Analytics to understand visitor traffic. The scopes required (chat.import, drive, etc.) are the minimum needed by the Google Chat Import API itself.',
+    answer: 'The tool is MIT licensed and fully open source — read every line before you run it. It makes no external network calls beyond the Google APIs required for migration. Your service account credentials are used locally and never transmitted anywhere. The tool itself has no telemetry, analytics, or phoning home. This website uses Cloudflare Web Analytics (cookieless, no personal data collected) to understand visitor traffic. The scopes required (chat.import, drive, etc.) are the minimum needed by the Google Chat Import API itself.',
   },
   {
     question: 'Is this tool free and open source?',
@@ -39,7 +39,7 @@ const faqs = [
 
     <div class="space-y-4">
       {faqs.map(faq => (
-        <details class="group rounded-xl border border-border bg-bg" data-ga-event="faq_open" data-ga-label={faq.question}>
+        <details class="group rounded-xl border border-border bg-bg">
           <summary class="flex cursor-pointer items-center justify-between px-6 py-4 text-left font-medium transition-colors hover:text-accent [&::-webkit-details-marker]:hidden">
             {faq.question}
             <svg

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -32,8 +32,6 @@ import TerminalDemo from './TerminalDemo.tsx';
     <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
       <a
         href="#quick-start"
-        data-ga-event="cta_click"
-        data-ga-label="hero_get_started"
         class="inline-flex items-center gap-2 rounded-lg bg-accent px-6 py-3 font-medium text-accent-contrast shadow-lg shadow-accent/25 transition-all hover:bg-accent/90 hover:shadow-xl hover:shadow-accent/30"
       >
         Get Started

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -18,19 +18,6 @@ const ogImage = new URL('/slack-chat-migrator/og-image.png', Astro.site);
 <!doctype html>
 <html lang="en" class="dark">
   <head>
-    <!-- Google Analytics -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-1F5723EMRV"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('consent', 'default', {
-        analytics_storage: 'denied',
-        ad_storage: 'denied',
-      });
-      gtag('js', new Date());
-      gtag('config', 'G-1F5723EMRV');
-    </script>
-
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
@@ -96,29 +83,7 @@ const ogImage = new URL('/slack-chat-migrator/og-image.png', Astro.site);
   <body class="min-h-screen">
     <slot />
 
-    <!-- Analytics: custom event tracking -->
-    <script is:inline>
-      document.addEventListener('click', function(e) {
-        var target = e.target;
-        while (target && !target.closest) {
-          target = target.parentElement;
-        }
-        if (!target) return;
-        var el = target.closest('[data-ga-event]');
-        if (el && typeof gtag === 'function') {
-          gtag('event', el.dataset.gaEvent, {
-            link_text: el.dataset.gaLabel || undefined
-          });
-        }
-      });
-      document.addEventListener('toggle', function(e) {
-        var el = e.target;
-        if (el && el.open && el.dataset.gaEvent && typeof gtag === 'function') {
-          gtag('event', el.dataset.gaEvent, {
-            faq_question: el.dataset.gaLabel || undefined
-          });
-        }
-      }, true);
-    </script>
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "7b8b528f5ec641e9a847161340b116ba"}'></script> <!-- pragma: allowlist secret -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove Google Analytics (GA4 in consent mode never collected usable data — requires high traffic + consented users for behavioral modeling, neither of which apply here)
- Add Cloudflare Web Analytics (cookieless, GDPR-compliant, no consent banner needed)
- Remove GA4 custom event tracking (click/toggle listeners, `data-ga-event` attributes, `gtag` calls in CopyButton)
- Update FAQ privacy disclosure to reflect Cloudflare analytics

## Test plan
- [ ] Verify Cloudflare Web Analytics beacon loads on deployed site
- [ ] Confirm hits appear in Cloudflare dashboard
- [ ] Verify no GA4/gtag references remain in page source